### PR TITLE
cat -> message

### DIFF
--- a/streamR/R/parseTweets.R
+++ b/streamR/R/parseTweets.R
@@ -141,7 +141,7 @@ parseTweets <- function(tweets, simplify=FALSE, verbose=TRUE){
     }
 
     # information message
-    if (verbose==TRUE) cat(length(df$text), "tweets have been parsed.", "\n")
+    if (verbose==TRUE) message(length(df$text), "tweets have been parsed.", "\n")
     return(df)
 }
 

--- a/streamR/R/parseTweets.R
+++ b/streamR/R/parseTweets.R
@@ -141,7 +141,7 @@ parseTweets <- function(tweets, simplify=FALSE, verbose=TRUE){
     }
 
     # information message
-    if (verbose==TRUE) message(length(df$text), "tweets have been parsed.", "\n")
+    if (verbose==TRUE) message(length(df$text), " tweets have been parsed.", "\n")
     return(df)
 }
 

--- a/streamR/R/readTweets.R
+++ b/streamR/R/readTweets.R
@@ -80,7 +80,7 @@ readTweets <- function(tweets, verbose=TRUE){
     }
               
     # information message
-    if (verbose==TRUE) cat(length(results.list), "tweets have been parsed.", "\n")
+    if (verbose==TRUE) message(length(results.list), " tweets have been parsed.", "\n")
     return(results.list)
 }
 


### PR DESCRIPTION
At two positions in the code I changed from cat() to message() because this is the recommended way of printing messages. One reason is that I can't suppress messages in my rmarkdown reports when they are written with `cat()` [see "One comment on messages"](http://yihui.name/knitr/demo/output/).

PS: I realised later that I can use `verbose=FALSE` but I think it's still better to have `message()` :)
